### PR TITLE
Added wide-character status to Emoji and Miscellaneous Symbols

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -143,12 +143,16 @@ func (c *Condition) RuneWidth(r rune) int {
 
 	if r >= 0x1100 &&
 		(r <= 0x115f || r == 0x2329 || r == 0x232a ||
+			(r >= 0x2600 && r <= 0x26FF) ||
+			(r >= 0x2700 && r <= 0x27BF) ||
 			(r >= 0x2e80 && r <= 0xa4cf && r != 0x303f) ||
 			(r >= 0xac00 && r <= 0xd7a3) ||
 			(r >= 0xf900 && r <= 0xfaff) ||
 			(r >= 0xfe30 && r <= 0xfe6f) ||
 			(r >= 0xff00 && r <= 0xff60) ||
 			(r >= 0xffe0 && r <= 0xffe6) ||
+			(r >= 0x1F300 && r <= 0x1F64F) ||
+			(r >= 0x1F680 && r <= 0x1F6FF) ||
 			(r >= 0x20000 && r <= 0x2fffd) ||
 			(r >= 0x30000 && r <= 0x3fffd)) {
 		return 2


### PR DESCRIPTION
I noticed when testing out a smiley emoji that this does not declare emoji as wide characters, so I found the blocks and added them in.  I will see if there are any emoji and misc. symbols that have a width of 1 rather than 2 and modify this, but for almost all (if not all) of the emoji and symbols, this works out well.