### PR TITLE
Restore ability to compile to JavaScript.

### DIFF
--- a/runewidth_js.go
+++ b/runewidth_js.go
@@ -1,0 +1,8 @@
+// +build js
+
+package runewidth
+
+func IsEastAsian() bool {
+	// TODO: Implement this for the web. Detect east asian in a compatible way, and return true.
+	return false
+}

--- a/runewidth_posix.go
+++ b/runewidth_posix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!js
 
 package runewidth
 


### PR DESCRIPTION
Current web-specific code implementation is not complete, and assumes non-east-asian. This is still an improvement because at least it compiles. But someone who has access to and is familiar with east-asian systems can complete the functionality.

This fixes the issue where I can no longer compile `markdownfmt` package to JavaScript, because it imports `go-runewidth`.

The posix solution uses `os.Getenv`, which [doesn't work](https://cloud.githubusercontent.com/assets/1924134/6206102/1979f5f4-b537-11e4-9c21-286145b4b79e.png) because "os" package imports "runtime", which is not fully supported.