### PR TITLE
don't truncate when input already fits

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -352,6 +352,9 @@ func (c *Condition) StringWidth(s string) (width int) {
 }
 
 func (c *Condition) Truncate(s string, w int, tail string) string {
+	if c.StringWidth(s) <= w {
+		return s
+	}
 	r := []rune(s)
 	tw := c.StringWidth(tail)
 	w -= tw


### PR DESCRIPTION
Before this change truncating `asdf` to a length of 4 with tail `…` will result
in `asd…`. After this change, it will return `asdf`.