### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mattn/go-runewidth
+
+go 1.9


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be adopted fully in Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go (although the import path doesn't change with this library, so it doesn't matter much here).

Because this library has no external dependencies, is still below version 2, and is already tagging its releases using semver compatible tags, not much changes in the library itself except to declare the canonical import path and the language being used in a `go.mod` file.
I picked Go 1.9 as the language being used because running tests with 1.9 appeared to work, and that's the earliest version that has some basic support for modules backported into it. Since only things using modules will read this file (and everything else will work exactly as it always had), that seemed like a safe bet for maximum compatibility. If you only support some higher version of Go and want to use features or APIs in a higher version this can be changed easily, of course.

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules