### PR TITLE
Bump github.com/rivo/uniseg to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mattn/go-runewidth
 
 go 1.9
 
-require github.com/rivo/uniseg v0.1.0
+require github.com/rivo/uniseg v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
-github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
This speed up and reduces the memory footprint of `uniseg.NewGraphemes`,
see https://github.com/rivo/uniseg@75711fccf6