### PR TITLE
Add full lookup table for single rune width.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -14,19 +14,42 @@ var benchSink int
 func benchRuneWidth(b *testing.B, eastAsianWidth bool, start, stop rune, want int) int {
 	b.Helper()
 	n := 0
-	got := -1
-	c := NewCondition()
-	c.EastAsianWidth = eastAsianWidth
-	for i := 0; i < b.N; i++ {
-		got = n
-		for r := start; r < stop; r++ {
-			n += c.RuneWidth(r)
+	b.Run("regular", func(b *testing.B) {
+		got := -1
+		c := NewCondition()
+		c.EastAsianWidth = eastAsianWidth
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			got = n
+			for r := start; r < stop; r++ {
+				n += c.RuneWidth(r)
+			}
+			got = n - got
 		}
-		got = n - got
-	}
-	if want != 0 && got != want { // some extra checks
-		b.Errorf("got %d, want %d\n", got, want)
-	}
+		if want != 0 && got != want { // some extra checks
+			b.Errorf("got %d, want %d\n", got, want)
+		}
+	})
+	b.Run("lut", func(b *testing.B) {
+		got := -1
+		n = 0
+		c := NewCondition()
+		c.EastAsianWidth = eastAsianWidth
+		c.CreateLUT()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			got = n
+			for r := start; r < stop; r++ {
+				n += c.RuneWidth(r)
+			}
+			got = n - got
+		}
+		if want != 0 && got != want { // some extra checks
+			b.Errorf("got %d, want %d\n", got, want)
+		}
+	})
 	return n
 }
 func BenchmarkRuneWidthAll(b *testing.B) {
@@ -49,20 +72,44 @@ func BenchmarkRuneWidth768EastAsian(b *testing.B) {
 func benchString1Width(b *testing.B, eastAsianWidth bool, start, stop rune, want int) int {
 	b.Helper()
 	n := 0
-	got := -1
-	c := NewCondition()
-	c.EastAsianWidth = eastAsianWidth
-	for i := 0; i < b.N; i++ {
-		got = n
-		for r := start; r < stop; r++ {
-			s := string(r)
-			n += c.StringWidth(s)
+	b.Run("regular", func(b *testing.B) {
+		got := -1
+		c := NewCondition()
+		c.EastAsianWidth = eastAsianWidth
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			got = n
+			for r := start; r < stop; r++ {
+				s := string(r)
+				n += c.StringWidth(s)
+			}
+			got = n - got
 		}
-		got = n - got
-	}
-	if want != 0 && got != want { // some extra checks
-		b.Errorf("got %d, want %d\n", got, want)
-	}
+		if want != 0 && got != want { // some extra checks
+			b.Errorf("got %d, want %d\n", got, want)
+		}
+	})
+	b.Run("lut", func(b *testing.B) {
+		got := -1
+		n = 0
+		c := NewCondition()
+		c.EastAsianWidth = eastAsianWidth
+		c.CreateLUT()
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			got = n
+			for r := start; r < stop; r++ {
+				s := string(r)
+				n += c.StringWidth(s)
+			}
+			got = n - got
+		}
+		if want != 0 && got != want { // some extra checks
+			b.Errorf("got %d, want %d\n", got, want)
+		}
+	})
 	return n
 }
 func BenchmarkString1WidthAll(b *testing.B) {

--- a/runewidth.go
+++ b/runewidth.go
@@ -34,7 +34,13 @@ func handleEnv() {
 		EastAsianWidth = env == "1"
 	}
 	// update DefaultCondition
-	DefaultCondition.EastAsianWidth = EastAsianWidth
+	if DefaultCondition.EastAsianWidth != EastAsianWidth {
+		DefaultCondition.EastAsianWidth = EastAsianWidth
+		if len(DefaultCondition.combinedLut) > 0 {
+			DefaultCondition.combinedLut = DefaultCondition.combinedLut[:0]
+			CreateLUT()
+		}
+	}
 }
 
 type interval struct {

--- a/runewidth.go
+++ b/runewidth.go
@@ -89,6 +89,7 @@ var nonprint = table{
 
 // Condition have flag EastAsianWidth whether the current locale is CJK or not.
 type Condition struct {
+	combinedLut        []byte
 	EastAsianWidth     bool
 	StrictEmojiNeutral bool
 }
@@ -104,10 +105,16 @@ func NewCondition() *Condition {
 // RuneWidth returns the number of cells in r.
 // See http://www.unicode.org/reports/tr11/
 func (c *Condition) RuneWidth(r rune) int {
+	if r < 0 || r > 0x10FFFF {
+		return 0
+	}
+	if len(c.combinedLut) > 0 {
+		return int(c.combinedLut[r>>1]>>(uint(r&1)*4)) & 3
+	}
 	// optimized version, verified by TestRuneWidthChecksums()
 	if !c.EastAsianWidth {
 		switch {
-		case r < 0x20 || r > 0x10FFFF:
+		case r < 0x20:
 			return 0
 		case (r >= 0x7F && r <= 0x9F) || r == 0xAD: // nonprint
 			return 0
@@ -124,7 +131,7 @@ func (c *Condition) RuneWidth(r rune) int {
 		}
 	} else {
 		switch {
-		case r < 0 || r > 0x10FFFF || inTables(r, nonprint, combining):
+		case inTables(r, nonprint, combining):
 			return 0
 		case inTable(r, narrow):
 			return 1
@@ -136,6 +143,27 @@ func (c *Condition) RuneWidth(r rune) int {
 			return 1
 		}
 	}
+}
+
+// CreateLUT will create an in-memory lookup table of 557056 bytes for faster operation.
+// This should not be called concurrently with other operations on c.
+// If options in c is changed, CreateLUT should be called again.
+func (c *Condition) CreateLUT() {
+	const max = 0x110000
+	lut := c.combinedLut
+	if len(c.combinedLut) != 0 {
+		// Remove so we don't use it.
+		c.combinedLut = nil
+	} else {
+		lut = make([]byte, max/2)
+	}
+	for i := range lut {
+		i32 := int32(i * 2)
+		x0 := c.RuneWidth(i32)
+		x1 := c.RuneWidth(i32 + 1)
+		lut[i] = uint8(x0) | uint8(x1)<<4
+	}
+	c.combinedLut = lut
 }
 
 // StringWidth return width as you can see
@@ -270,4 +298,13 @@ func FillLeft(s string, w int) string {
 // FillRight return string filled in left by spaces in w cells
 func FillRight(s string, w int) string {
 	return DefaultCondition.FillRight(s, w)
+}
+
+// CreateLUT will create an in-memory lookup table of 557055 bytes for faster operation.
+// This should not be called concurrently with other operations.
+func CreateLUT() {
+	if len(DefaultCondition.combinedLut) > 0 {
+		return
+	}
+	DefaultCondition.CreateLUT()
 }


### PR DESCRIPTION
Provides nearly an order of magnitude speedup depending on how quickly the checks are done.

Data is packed at 4 bytes/rune, since the max output value is 2.

```
cpu: AMD Ryzen 9 3950X 16-Core Processor
BenchmarkRuneWidthAll/regular-32        	      51	  25539433 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneWidthAll/lut-32            	     442	   2711694 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneWidth768/regular-32        	  617528	      2109 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneWidth768/lut-32            	  605570	      2038 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneWidthAllEastAsian/regular-32         	      31	  36469868 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneWidthAllEastAsian/lut-32             	     442	   2710229 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneWidth768EastAsian/regular-32         	   73273	     16028 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneWidth768EastAsian/lut-32             	  634987	      1871 ns/op	       0 B/op	       0 allocs/op
PASS
```