### PR TITLE
Add //go:build lines

### DIFF
--- a/runewidth_appengine.go
+++ b/runewidth_appengine.go
@@ -1,3 +1,4 @@
+//go:build appengine
 // +build appengine
 
 package runewidth

--- a/runewidth_js.go
+++ b/runewidth_js.go
@@ -1,5 +1,5 @@
-// +build js
-// +build !appengine
+//go:build js && !appengine
+// +build js,!appengine
 
 package runewidth
 

--- a/runewidth_posix.go
+++ b/runewidth_posix.go
@@ -1,6 +1,5 @@
-// +build !windows
-// +build !js
-// +build !appengine
+//go:build !windows && !js && !appengine
+// +build !windows,!js,!appengine
 
 package runewidth
 

--- a/runewidth_posix_test.go
+++ b/runewidth_posix_test.go
@@ -1,6 +1,5 @@
-// +build !windows
-// +build !js
-// +build !appengine
+//go:build !windows && !js && !appengine
+// +build !windows,!js,!appengine
 
 package runewidth
 

--- a/runewidth_windows.go
+++ b/runewidth_windows.go
@@ -1,5 +1,5 @@
-// +build windows
-// +build !appengine
+//go:build windows && !appengine
+// +build windows,!appengine
 
 package runewidth
 


### PR DESCRIPTION
Starting with Go 1.17, `//go:build` lines are preferred over `// +build`
lines, see https://golang.org/doc/go1.17#build-lines and
https://golang.org/design/draft-gobuild for details.

This change was generated by running Go 1.17 `go fmt ./...` which
automatically adds `//go:build` lines based on the existing `// +build`
lines.