### PR TITLE
Avoid rune slice allocation to range over string

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -218,7 +218,7 @@ func (c *Condition) Truncate(s string, w int, tail string) string {
 func (c *Condition) Wrap(s string, w int) string {
 	width := 0
 	out := ""
-	for _, r := range []rune(s) {
+	for _, r := range s {
 		cw := c.RuneWidth(r)
 		if r == '\n' {
 			out += string(r)


### PR DESCRIPTION
In Go, for loop range over `[]rune(string(s))` is effectively equal to rang over `string(s)`. Not sure the compiler is smart enough to eliminate this allocation, but anyway this looks better IMO.