### PR TITLE
Upgraded rivo/uniseg to latest version, switched StringWidth/Truncate to speedier version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mattn/go-runewidth
 
 go 1.9
 
-require github.com/rivo/uniseg v0.2.0
+require github.com/rivo/uniseg v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.3.0 h1:eyC18g7xB83Dv/xlJXLgNkRidVoR7nqFZBJvqo/K188=
+github.com/rivo/uniseg v0.3.0/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
The [`rivo/uniseg`](https://github.com/rivo/uniseg) package has received a major update which also includes methods for grapheme cluster parsing that are much faster than the previously used `Graphemes` class.

I've upgraded your package accordingly and updated the relevant code to use these faster methods. It would be great if you could merge these changes.

Thank you!