### PR TITLE
bump GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,8 @@ jobs:
         go: ["1.15", "1.16"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
 
@@ -24,4 +24,4 @@ jobs:
       - run: go test ./... -v -cover -coverprofile coverage.out
       - run: go test -bench . -benchmem
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3


### PR DESCRIPTION
actions/checkout@v2, actions/setup-go@v2 and codecov/codecov-action@v1 use Node.js v12 that is already deprecated.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

We need upgrade the latest one.