### PR TITLE
go.mod: update to go1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/mattn/go-runewidth
 
-go 1.9
+go 1.18
 
 require github.com/rivo/uniseg v0.2.0


### PR DESCRIPTION
Closes #71 

The dependency uniseg requires a minimum go version of 1.18, and so `go.mod` was updated to reflect that accordingly.