### PR TITLE
add early exit to inTable

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -64,6 +64,9 @@ func inTable(r rune, t table) bool {
 	if r < t[0].first {
 		return false
 	}
+	if r > t[len(t)-1].last {
+		return false
+	}
 
 	bot := 0
 	top := len(t) - 1


### PR DESCRIPTION
Not sure why this was missing.
It has a significant impact on my bubbletea application.


goos: darwin
goarch: arm64
pkg: github.com/mattn/go-runewidth
                                   │      a       │                  b                   │
                                   │    sec/op    │    sec/op     vs base                │
RuneWidthAll/regular-8               21.139m ± 0%   9.175m ±  1%  -56.60% (p=0.000 n=10)
RuneWidthAll/lut-8                    2.417m ± 1%   2.672m ± 10%  +10.57% (p=0.001 n=10)
RuneWidth768/regular-8                1.712µ ± 1%   1.961µ ± 14%  +14.55% (p=0.023 n=10)
RuneWidth768/lut-8                    1.650µ ± 2%   1.680µ ±  4%   +1.82% (p=0.006 n=10)
RuneWidthAllEastAsian/regular-8       25.67m ± 2%   17.20m ±  1%  -33.02% (p=0.000 n=10)
RuneWidthAllEastAsian/lut-8           2.385m ± 2%   2.552m ±  8%   +7.02% (p=0.005 n=10)
RuneWidth768EastAsian/regular-8       13.58µ ± 0%   14.99µ ±  1%  +10.39% (p=0.000 n=10)
RuneWidth768EastAsian/lut-8           1.662µ ± 1%   1.680µ ± 22%   +1.08% (p=0.006 n=10)
String1WidthAll/regular-8             129.0m ± 0%   119.4m ±  1%   -7.50% (p=0.000 n=10)
String1WidthAll/lut-8                 113.3m ± 0%   114.5m ±  2%   +1.09% (p=0.001 n=10)
String1Width768/regular-8             74.05µ ± 0%   73.91µ ±  0%        ~ (p=0.089 n=10)
String1Width768/lut-8                 74.11µ ± 1%   74.77µ ±  0%   +0.89% (p=0.023 n=10)
String1WidthAllEastAsian/regular-8    134.6m ± 2%   129.5m ±  1%   -3.83% (p=0.000 n=10)
String1WidthAllEastAsian/lut-8        113.3m ± 1%   114.7m ±  2%   +1.23% (p=0.001 n=10)
String1Width768EastAsian/regular-8    88.55µ ± 0%   90.42µ ±  0%   +2.12% (p=0.000 n=10)
String1Width768EastAsian/lut-8        74.11µ ± 0%   74.66µ ±  1%   +0.74% (p=0.001 n=10)
TablePrivate-8                        3.435m ± 0%   3.768m ± 14%   +9.70% (p=0.000 n=10)
TableNonprint-8                      3038.1µ ± 1%   922.9µ ±  0%  -69.62% (p=0.000 n=10)
TableCombining-8                      4.624m ± 0%   1.293m ±  0%  -72.04% (p=0.000 n=10)
TableDoublewidth-8                    5.477m ± 0%   2.019m ±  1%  -63.13% (p=0.000 n=10)
TableAmbiguous-8                      6.185m ± 0%   6.387m ±  1%   +3.27% (p=0.000 n=10)
TableEmoji-8                          5.515m ± 0%   1.493m ±  0%  -72.93% (p=0.000 n=10)
TableNarrow-8                        2453.4µ ± 0%   727.3µ ±  0%  -70.36% (p=0.000 n=10)
TableNeutral-8                        8.173m ± 1%   7.140m ±  0%  -12.64% (p=0.000 n=10)
geomean                               1.266m        951.6µ        -24.86%


