### PR TITLE
Add TruncatePrefix

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -251,6 +251,38 @@ func (c *Condition) TruncateLeft(s string, w int, prefix string) string {
 	return prefix + s[pos:]
 }
 
+// Truncate return string truncated with w cells from prefix part (left part)
+func (c *Condition) TruncatePrefix(s string, w int, prefix string) string {
+	if c.StringWidth(prefix) >= w {
+		return prefix
+	}
+
+	sw := c.StringWidth(s)
+	if sw <= w {
+		return s
+	}
+	w -= c.StringWidth(prefix)
+	var width int
+	var pos int
+	g := uniseg.NewGraphemes(s)
+	for g.Next() {
+		var chWidth int
+		for _, r := range g.Runes() {
+			chWidth = c.RuneWidth(r)
+			if chWidth > 0 {
+				break // See StringWidth() for details.
+			}
+		}
+		if sw-(width+chWidth) <= w {
+			_, pos = g.Positions()
+			break
+		}
+		width += chWidth
+	}
+
+	return prefix + s[pos:]
+}
+
 // Wrap return string wrapped with w cells
 func (c *Condition) Wrap(s string, w int) string {
 	width := 0
@@ -331,6 +363,11 @@ func Truncate(s string, w int, tail string) string {
 // TruncateLeft cuts w cells from the beginning of the `s`.
 func TruncateLeft(s string, w int, prefix string) string {
 	return DefaultCondition.TruncateLeft(s, w, prefix)
+}
+
+// Truncate return string truncated with w cells from prefix part (left part)
+func TruncatePrefix(s string, w int, prefix string) string {
+	return DefaultCondition.TruncatePrefix(s, w, prefix)
 }
 
 // Wrap return string wrapped with w cells

--- a/runewidth_test.go
+++ b/runewidth_test.go
@@ -406,6 +406,40 @@ func TestTruncateLeft(t *testing.T) {
 	}
 }
 
+var truncateprefixtests = []struct {
+	s      string
+	w      int
+	prefix string
+	out    string
+}{
+	{"source", 4, "*", "*rce"},
+	{"source", 6, "*", "source"},
+	{"あいうえお", 4, "*", "*お"},
+	{"あいうえお", 10, "*", "あいうえお"},
+	{"Aあいうえお", 5, "*", "*えお"},
+
+	{"source", 4, "", "urce"},
+	{"source", 4, "...", "...e"},
+	{"あいうえお", 6, "", "うえお"},
+	{"あいうえお", 6, "...", "...お"},
+	{"あいうえお", 10, "", "あいうえお"},
+	{"あいうえお", 10, "...", "あいうえお"},
+	{"あいうえお", 5, "", "えお"},
+
+	{"source", 1, "*", "*"},
+	{"source", 0, "*", "*"}, // same as Truncate
+}
+
+func TestTruncatePrefix(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range truncateprefixtests {
+		if out := TruncatePrefix(tt.s, tt.w, tt.prefix); out != tt.out {
+			t.Errorf("TruncatePrefix(%q) = %q, want %q", tt.s, out, tt.out)
+		}
+	}
+}
+
 var isneutralwidthtests = []struct {
 	in  rune
 	out bool


### PR DESCRIPTION
Hello.

I have added a new `TruncatePrefix` in addition to the `Truncate` and `TruncateLeft` method.
For example, when displaying a file pathname in the terminal, the string on the right side is more important for the information.
In such cases, one may want to truncate from the left side.

`TruncateLeft` might be a more appropriate name for this method, but since it already existed, I chose `TruncatePrefix`.