### PR TITLE
add trick for Windows Terminal

### DIFF
--- a/runewidth_windows.go
+++ b/runewidth_windows.go
@@ -16,7 +16,7 @@ var (
 // IsEastAsian return true if the current locale is CJK
 func IsEastAsian() bool {
 	if os.Getenv("WT_SESSION") != "" {
-		// Windows Terminal is always UTF-8
+		// Windows Terminal always not use East Asian Ambiguous Width(s).
 		return false
 	}
 

--- a/runewidth_windows.go
+++ b/runewidth_windows.go
@@ -4,6 +4,7 @@
 package runewidth
 
 import (
+	"os"
 	"syscall"
 )
 
@@ -14,6 +15,11 @@ var (
 
 // IsEastAsian return true if the current locale is CJK
 func IsEastAsian() bool {
+	if os.Getenv("WT_SESSION") != "" {
+		// Windows Terminal is always UTF-8
+		return false
+	}
+
 	r1, _, _ := procGetConsoleOutputCP.Call()
 	if r1 == 0 {
 		return false


### PR DESCRIPTION
Windows Terminal always not use East Asian Ambiguous Width(s).

before
<img width="1130" height="473" alt="image" src="https://github.com/user-attachments/assets/8340e692-9979-4362-bc49-2f7d36219ddb" />

after
<img width="1109" height="524" alt="image" src="https://github.com/user-attachments/assets/f71a6032-5306-459a-99f0-2e52953908ac" />
