### PR TITLE
Optimize RuneWidth and StringWidth performance

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -24,8 +24,46 @@ var (
 	}
 )
 
+var (
+	zerowidth table // combining + nonprint merged for faster zero-width lookup
+	widewidth table // ambiguous + doublewidth merged for EA path
+)
+
 func init() {
+	zerowidth = mergeIntervals(combining, nonprint)
+	widewidth = mergeIntervals(ambiguous, doublewidth)
 	handleEnv()
+}
+
+func mergeIntervals(t1, t2 table) table {
+	merged := make(table, 0, len(t1)+len(t2))
+	i, j := 0, 0
+	for i < len(t1) && j < len(t2) {
+		if t1[i].first <= t2[j].first {
+			merged = append(merged, t1[i])
+			i++
+		} else {
+			merged = append(merged, t2[j])
+			j++
+		}
+	}
+	merged = append(merged, t1[i:]...)
+	merged = append(merged, t2[j:]...)
+	if len(merged) == 0 {
+		return merged
+	}
+	result := merged[:1]
+	for _, iv := range merged[1:] {
+		last := &result[len(result)-1]
+		if iv.first <= last.last+1 {
+			if iv.last > last.last {
+				last.last = iv.last
+			}
+		} else {
+			result = append(result, iv)
+		}
+	}
+	return result
 }
 
 func handleEnv() {
@@ -51,15 +89,6 @@ type interval struct {
 }
 
 type table []interval
-
-func inTables(r rune, ts ...table) bool {
-	for _, t := range ts {
-		if inTable(r, t) {
-			return true
-		}
-	}
-	return false
-}
 
 func inTable(r rune, t table) bool {
 	if r < t[0].first {
@@ -131,9 +160,7 @@ func (c *Condition) RuneWidth(r rune) int {
 			return 0
 		case r < 0x300:
 			return 1
-		case inTable(r, narrow):
-			return 1
-		case inTables(r, nonprint, combining):
+		case inTable(r, zerowidth):
 			return 0
 		case inTable(r, doublewidth):
 			return 2
@@ -142,13 +169,13 @@ func (c *Condition) RuneWidth(r rune) int {
 		}
 	} else {
 		switch {
-		case inTables(r, nonprint, combining):
+		case inTable(r, zerowidth):
 			return 0
 		case inTable(r, narrow):
 			return 1
-		case inTables(r, ambiguous, doublewidth):
+		case inTable(r, widewidth):
 			return 2
-		case !c.StrictEmojiNeutral && inTables(r, ambiguous, emoji, narrow):
+		case !c.StrictEmojiNeutral && inTable(r, emoji):
 			return 2
 		default:
 			return 1
@@ -185,6 +212,16 @@ func (c *Condition) StringWidth(s string) (width int) {
 			return c.RuneWidth(r)
 		}
 	}
+	// ASCII fast path: no grapheme clustering needed for pure ASCII
+	if isAllASCII(s) {
+		for i := 0; i < len(s); i++ {
+			b := s[i]
+			if b >= 0x20 && b != 0x7F {
+				width++
+			}
+		}
+		return
+	}
 	g := graphemes.FromString(s)
 	for g.Next() {
 		var chWidth int
@@ -197,6 +234,15 @@ func (c *Condition) StringWidth(s string) (width int) {
 		width += chWidth
 	}
 	return
+}
+
+func isAllASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 // Truncate return string truncated with w cells
@@ -264,24 +310,25 @@ func (c *Condition) TruncateLeft(s string, w int, prefix string) string {
 // Wrap return string wrapped with w cells
 func (c *Condition) Wrap(s string, w int) string {
 	width := 0
-	out := ""
+	var out strings.Builder
+	out.Grow(len(s) + len(s)/w + 1)
 	for _, r := range s {
 		cw := c.RuneWidth(r)
 		if r == '\n' {
-			out += string(r)
+			out.WriteRune(r)
 			width = 0
 			continue
 		} else if width+cw > w {
-			out += "\n"
+			out.WriteByte('\n')
 			width = 0
-			out += string(r)
+			out.WriteRune(r)
 			width += cw
 			continue
 		}
-		out += string(r)
+		out.WriteRune(r)
 		width += cw
 	}
-	return out
+	return out.String()
 }
 
 // FillLeft return string filled in left by spaces in w cells
@@ -320,7 +367,7 @@ func RuneWidth(r rune) int {
 
 // IsAmbiguousWidth returns whether is ambiguous width or not.
 func IsAmbiguousWidth(r rune) bool {
-	return inTables(r, private, ambiguous)
+	return inTable(r, private) || inTable(r, ambiguous)
 }
 
 // IsCombiningWidth returns whether is combining width or not.


### PR DESCRIPTION
The non-LUT path of RuneWidth was performing multiple binary searches per rune across combining, nonprint, doublewidth, and other tables. By merging tables that return the same width at init time, the number of searches is reduced. Specifically, combining and nonprint are merged into a single zerowidth table, and ambiguous and doublewidth are merged into a widewidth table used only in the EastAsian path where both return width 2.

The redundant narrow table lookup in the non-EastAsian path was also removed since its result (width 1) is identical to the default case. The variadic inTables function, which allocated a slice on each call, has been replaced with direct || expressions.

StringWidth now has a fast path for pure ASCII strings that bypasses the grapheme segmenter entirely. Wrap replaces string concatenation with strings.Builder, improving from O(n²) to O(n).

The merged tables are computed at init from the existing generated tables, so no manual maintenance is needed when the Unicode version is updated. TestRuneWidthChecksums confirms via SHA256 that all rune widths remain identical.

```
                                    │     old      │            new             │
                                    │    sec/op    │   sec/op     vs base       │
RuneWidthAll/regular-16               25.28m ± 5%   16.56m ± 4%  -34.49%
RuneWidthAll/lut-16                   5.479m ± 4%   4.487m ± 2%  -18.10%
RuneWidthAllEastAsian/regular-16      47.15m ±22%   26.03m ± 9%  -44.79%
RuneWidthAllEastAsian/lut-16          5.414m ± 2%   4.410m ± 4%  -18.54%
RuneWidth768/lut-16                   3.720µ ±10%   2.788µ ± 6%  -25.06%
RuneWidth768EastAsian/regular-16      25.72µ ± 3%   22.72µ ± 4%  -11.66%
RuneWidth768EastAsian/lut-16          3.601µ ± 5%   2.916µ ± 6%  -19.04%
String1WidthAll/regular-16            46.28m ±11%   34.47m ± 7%  -25.53%
String1WidthAll/lut-16                23.57m ± 9%   21.20m ± 7%  -10.04%
String1WidthAllEastAsian/regular-16   58.22m ± 2%   43.19m ± 2%  -25.81%
String1WidthAllEastAsian/lut-16       23.22m ± 4%   20.73m ± 3%  -10.69%
String1Width768/lut-16                14.45µ ± 2%   13.15µ ± 5%   -8.96%
String1Width768EastAsian/regular-16   37.55µ ± 4%   33.38µ ± 7%  -11.11%
String1Width768EastAsian/lut-16       14.38µ ± 5%   12.82µ ± 6%  -10.83%
geomean                               481.0µ        395.9µ       -17.69%
```