### PR TITLE
fix: Truncate when tail is wider than the limit

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -333,7 +333,16 @@ func (c *Condition) Truncate(s string, w int, tail string) string {
 	if c.StringWidth(s) <= w {
 		return s
 	}
-	w -= c.StringWidth(tail)
+	tw := c.StringWidth(tail)
+	// If the tail alone does not fit, return a truncated tail rather than
+	// treating a negative remaining width as "empty prefix + full tail".
+	if tw >= w {
+		if w <= 0 {
+			return ""
+		}
+		return c.Truncate(tail, w, "")
+	}
+	w -= tw
 	var width int
 	pos := len(s)
 	g := graphemes.FromString(s)

--- a/runewidth_test.go
+++ b/runewidth_test.go
@@ -521,3 +521,16 @@ func TestZeroWidthJoiner(t *testing.T) {
 		}
 	}
 }
+
+
+func TestTruncateTailWiderThanWidth(t *testing.T) {
+	// tail wider than limit: must not return the oversized tail alone
+	out := Truncate("hello world", 2, "...")
+	if StringWidth(out) > 2 {
+		t.Errorf("Truncate width=%d for %q, want <= 2", StringWidth(out), out)
+	}
+	out = Truncate("hello", 0, "...")
+	if out != "" {
+		t.Errorf("Truncate w=0 got %q, want empty", out)
+	}
+}


### PR DESCRIPTION
## Summary
`Truncate(s, w, tail)` did `w -= StringWidth(tail)` without checking the tail width. When the tail was wider than `w`, the remaining width went negative and the function returned the **full tail**, which could be wider than the requested limit.

## Changes
- If `StringWidth(tail) >= w`, truncate the tail to `w` (or return `\"\"` when `w <= 0`)
- Regression test for tail-wider-than-width and `w == 0`

## Test plan
- [x] `go test -run Truncate .`