### PR TITLE
fix: do not panic in Wrap when width is zero or negative

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -390,8 +390,12 @@ func (c *Condition) TruncateLeft(s string, w int, prefix string) string {
 	return prefix + s[pos:]
 }
 
-// Wrap return string wrapped with w cells
+// Wrap returns a string wrapped to at most w cells per line.
+// If w is zero or negative, s is returned unchanged.
 func (c *Condition) Wrap(s string, w int) string {
+	if w <= 0 {
+		return s
+	}
 	width := 0
 	var out strings.Builder
 	out.Grow(len(s) + len(s)/w + 1)
@@ -478,7 +482,7 @@ func TruncateLeft(s string, w int, prefix string) string {
 	return DefaultCondition.TruncateLeft(s, w, prefix)
 }
 
-// Wrap return string wrapped with w cells
+// Wrap returns a string wrapped to at most w cells per line.
 func Wrap(s string, w int) string {
 	return DefaultCondition.Wrap(s, w)
 }

--- a/runewidth_test.go
+++ b/runewidth_test.go
@@ -521,3 +521,13 @@ func TestZeroWidthJoiner(t *testing.T) {
 		}
 	}
 }
+
+func TestWrapZeroOrNegativeWidth(t *testing.T) {
+	s := "hello world"
+	for _, w := range []int{0, -1, -10} {
+		out := Wrap(s, w)
+		if out != s {
+			t.Errorf("Wrap(%q, %d) = %q, want unchanged", s, w, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
`Wrap(s, 0)` panicked with `integer divide by zero` because capacity was computed as `len(s)/w`.

## Changes
- If `w <= 0`, return `s` unchanged (no wrap)
- Clarify godoc
- Regression test for `w <= 0`

## Test plan
- [x] `go test -run Wrap .`