### PR TITLE
Restore ZeroWidthJoiner as a deprecated no-op

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -18,6 +18,14 @@ var (
 	// StrictEmojiNeutral should be set false if handle broken fonts
 	StrictEmojiNeutral bool = true
 
+	// ZeroWidthJoiner is flag to set to use UTR#51 ZWJ.
+	//
+	// Deprecated: ZWJ sequences are always handled through Unicode
+	// grapheme cluster segmentation now, so this flag has no effect.
+	// It is kept only for compatibility with code written against
+	// v0.0.9 and earlier.
+	ZeroWidthJoiner bool
+
 	// DefaultCondition is a condition in current locale
 	DefaultCondition = &Condition{
 		EastAsianWidth:     false,
@@ -258,6 +266,12 @@ type Condition struct {
 	combinedLut        []byte
 	EastAsianWidth     bool
 	StrictEmojiNeutral bool
+
+	// Deprecated: ZWJ sequences are always handled through Unicode
+	// grapheme cluster segmentation now, so this flag has no effect.
+	// It is kept only for compatibility with code written against
+	// v0.0.9 and earlier.
+	ZeroWidthJoiner bool
 }
 
 // NewCondition return new instance of Condition which is current locale.
@@ -265,6 +279,7 @@ func NewCondition() *Condition {
 	return &Condition{
 		EastAsianWidth:     EastAsianWidth,
 		StrictEmojiNeutral: StrictEmojiNeutral,
+		ZeroWidthJoiner:    ZeroWidthJoiner,
 	}
 }
 

--- a/runewidth_test.go
+++ b/runewidth_test.go
@@ -569,3 +569,14 @@ func TestZeroWidthJoiner(t *testing.T) {
 		}
 	}
 }
+
+func TestZeroWidthJoinerFlag(t *testing.T) {
+	// The deprecated flag must compile and must not change any result.
+	for _, zwj := range []bool{true, false} {
+		c := NewCondition()
+		c.ZeroWidthJoiner = zwj
+		if got := c.StringWidth("👨‍👨‍👧"); got != 2 {
+			t.Errorf("StringWidth with ZeroWidthJoiner=%v = %d, want 2", zwj, got)
+		}
+	}
+}


### PR DESCRIPTION
The ZeroWidthJoiner package variable and Condition field were removed in v0.0.10, which broke code written against v0.0.9 as reported in #58. ZWJ sequences are always handled through Unicode grapheme cluster segmentation now, so the flag has no effect on any result, but restoring the symbols as deprecated no-ops lets that old code compile with current versions again.