### PR TITLE
Build the width lookup tables lazily to fix the startup regression

### DIFF
--- a/runewidth.go
+++ b/runewidth.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"unicode/utf8"
 
 	"github.com/clipperhouse/uax29/v2/graphemes"
@@ -34,22 +36,73 @@ var (
 )
 
 var (
-	zerowidth       table // combining + nonprint merged for faster zero-width lookup
-	widewidth       table // ambiguous + doublewidth merged for EA path
-	eastAsianWidth  widthTable
-	eastAsianWidth0 [0x300]byte
-	strictWidthLUT  [2][0x110000]byte
+	zerowidth      table // combining + nonprint merged for faster zero-width lookup
+	widewidth      table // ambiguous + doublewidth merged for EA path
+	eastAsianWidth widthTable
+	tablesOnce     sync.Once
+
+	// strictWidthLUT is mostly built lazily on the first width lookup so
+	// that importing the package costs neither the build time nor the 2 MB
+	// of resident memory; see issue #104. Only the entries below
+	// strictWidthLUTLimit are valid: init fills the first 0x300 entries of
+	// both planes, and the lazy build fills the rest — never rewriting the
+	// low region, so readers of it cannot race with the build. The limit
+	// is loaded with acquire semantics, which makes the non-atomic reads
+	// of the high region safe once it reports 0x110000. Keeping the whole
+	// check down to one compare-and-branch matters: RuneWidth is only a
+	// dozen instructions long.
+	strictWidthLUT      [2][0x110000]byte
+	strictWidthLUTLimit atomic.Int32
+	strictWidthLUTOnce  sync.Once
 )
 
 func init() {
+	initStrictWidthLUTLow()
+	strictWidthLUTLimit.Store(0x300)
+	handleEnv()
+}
+
+// initStrictWidthLUTLow paints the first 0x300 entries of strictWidthLUT
+// from the static interval tables. The result must stay identical to
+// runeWidthNoLUT for runes below 0x300, which TestStrictWidthLUT verifies.
+func initStrictWidthLUTLow() {
+	for i := 0; i < 0x300; i++ {
+		r := rune(i)
+		w := byte(1)
+		if r < 0x20 || (r >= 0x7F && r <= 0x9F) || r == 0xAD { // nonprint
+			w = 0
+		}
+		strictWidthLUT[0][i] = w
+	}
+
+	ea := strictWidthLUT[1][:0x300]
+	fillBytes(ea, 1)
+	paint := func(t table, w byte) {
+		for _, iv := range t {
+			if iv.first >= 0x300 {
+				break
+			}
+			last := iv.last
+			if last > 0x2FF {
+				last = 0x2FF
+			}
+			fillBytes(ea[iv.first:last+1], w)
+		}
+	}
+	paint(ambiguous, 2)
+	paint(doublewidth, 2)
+	// zero-width wins over wide on overlap, so paint it last.
+	paint(combining, 0)
+	paint(nonprint, 0)
+}
+
+// initTables builds the merged lookup tables. It runs lazily through
+// tablesOnce so that merely importing the package stays cheap; see issue
+// #104.
+func initTables() {
 	zerowidth = mergeIntervals(combining, nonprint)
 	widewidth = mergeIntervals(ambiguous, doublewidth)
 	eastAsianWidth = makeWidthTable(zerowidth, widewidth)
-	for r := range eastAsianWidth0 {
-		eastAsianWidth0[r] = byte(runeWidthEastAsianNoCache(rune(r), true))
-	}
-	initStrictWidthLUT()
-	handleEnv()
 }
 
 func mergeIntervals(t1, t2 table) table {
@@ -200,6 +253,7 @@ func inWidthTable(r rune, t widthTable) (int, bool) {
 }
 
 func runeWidthNoLUT(r rune, eastAsian, strictEmojiNeutral bool) int {
+	tablesOnce.Do(initTables)
 	if !eastAsian {
 		if r < 0x20 {
 			return 0
@@ -221,7 +275,7 @@ func runeWidthNoLUT(r rune, eastAsian, strictEmojiNeutral bool) int {
 	}
 
 	if r < 0x300 {
-		return int(eastAsianWidth0[r])
+		return int(strictWidthLUT[1][r])
 	}
 	if w, ok := inWidthTable(r, eastAsianWidth); ok {
 		return w
@@ -232,22 +286,60 @@ func runeWidthNoLUT(r rune, eastAsian, strictEmojiNeutral bool) int {
 	return 1
 }
 
-func runeWidthEastAsianNoCache(r rune, strictEmojiNeutral bool) int {
-	if w, ok := inWidthTable(r, eastAsianWidth); ok {
-		return w
+// fillBytes sets every byte of b to v. It doubles the copied region on each
+// iteration so large slices are filled at memcpy speed instead of one byte
+// per loop iteration.
+func fillBytes(b []byte, v byte) {
+	if len(b) == 0 {
+		return
 	}
-	if !strictEmojiNeutral && inTable(r, emoji) {
-		return 2
+	b[0] = v
+	for i := 1; i < len(b); i *= 2 {
+		copy(b[i:], b[:i])
 	}
-	return 1
 }
 
-func initStrictWidthLUT() {
-	for i := range strictWidthLUT[0] {
-		r := rune(i)
-		strictWidthLUT[0][i] = byte(runeWidthNoLUT(r, false, true))
-		strictWidthLUT[1][i] = byte(runeWidthNoLUT(r, true, true))
-	}
+// buildStrictWidthLUT builds the strict-width lookup table above 0x300
+// exactly once. It paints whole intervals instead of computing every rune
+// through the binary searches in runeWidthNoLUT. It must not write below
+// 0x300: that region was filled by init and may be read concurrently. The
+// result must stay identical to runeWidthNoLUT(r, eastAsian, true), which
+// TestStrictWidthLUT verifies.
+func buildStrictWidthLUT() {
+	strictWidthLUTOnce.Do(func() {
+		tablesOnce.Do(initTables)
+
+		// paintHigh fills lut with w over each interval, clipped to 0x300+.
+		paintHigh := func(lut []byte, first, last rune, w byte) {
+			if first < 0x300 {
+				if last < 0x300 {
+					return
+				}
+				first = 0x300
+			}
+			fillBytes(lut[first:last+1], w)
+		}
+
+		// EastAsianWidth=false, StrictEmojiNeutral=true
+		lut := strictWidthLUT[0][:]
+		fillBytes(lut[0x300:], 1)
+		for _, iv := range doublewidth {
+			paintHigh(lut, iv.first, iv.last, 2)
+		}
+		// zerowidth is checked before doublewidth, so it wins on overlap.
+		for _, iv := range zerowidth {
+			paintHigh(lut, iv.first, iv.last, 0)
+		}
+
+		// EastAsianWidth=true, StrictEmojiNeutral=true
+		lut = strictWidthLUT[1][:]
+		fillBytes(lut[0x300:], 1)
+		for _, iv := range eastAsianWidth {
+			paintHigh(lut, iv.first, iv.last, iv.width)
+		}
+
+		strictWidthLUTLimit.Store(0x110000)
+	})
 }
 
 var private = table{
@@ -286,9 +378,30 @@ func NewCondition() *Condition {
 // RuneWidth returns the number of cells in r.
 // See http://www.unicode.org/reports/tr11/
 func (c *Condition) RuneWidth(r rune) int {
+	// This one compare doubles as the range check and the lazy-LUT check:
+	// out-of-range runes and runes above the built portion of
+	// strictWidthLUT both take the slow path. Once the LUT is fully built
+	// the limit is 0x110000 and only invalid runes go slow.
+	if uint32(r) >= uint32(strictWidthLUTLimit.Load()) {
+		return c.runeWidthSlow(r)
+	}
+	if len(c.combinedLut) > 0 {
+		return int(c.combinedLut[r>>1]>>(uint(r&1)*4)) & 3
+	}
+	if c.StrictEmojiNeutral {
+		if c.EastAsianWidth {
+			return int(strictWidthLUT[1][r])
+		}
+		return int(strictWidthLUT[0][r])
+	}
+	return runeWidthNoLUT(r, c.EastAsianWidth, c.StrictEmojiNeutral)
+}
+
+func (c *Condition) runeWidthSlow(r rune) int {
 	if r < 0 || r > 0x10FFFF {
 		return 0
 	}
+	buildStrictWidthLUT()
 	if len(c.combinedLut) > 0 {
 		return int(c.combinedLut[r>>1]>>(uint(r&1)*4)) & 3
 	}

--- a/runewidth_posix.go
+++ b/runewidth_posix.go
@@ -5,35 +5,50 @@ package runewidth
 
 import (
 	"os"
-	"regexp"
 	"strings"
 )
 
-var reLoc = regexp.MustCompile(`^[a-z][a-z][a-z]?(?:_[A-Z][A-Z])?\.(.+)`)
+func mblen(charset string) int {
+	switch charset {
+	case "utf-8", "utf8":
+		return 6
+	case "jis":
+		return 8
+	case "eucjp":
+		return 3
+	case "euckr", "euccn", "sjis", "cp932", "cp51932", "cp936", "cp949", "cp950", "big5", "gbk", "gb2312":
+		return 2
+	}
+	return 1
+}
 
-var mblenTable = map[string]int{
-	"utf-8":   6,
-	"utf8":    6,
-	"jis":     8,
-	"eucjp":   3,
-	"euckr":   2,
-	"euccn":   2,
-	"sjis":    2,
-	"cp932":   2,
-	"cp51932": 2,
-	"cp936":   2,
-	"cp949":   2,
-	"cp950":   2,
-	"big5":    2,
-	"gbk":     2,
-	"gb2312":  2,
+// localeCharset extracts the charset part of a locale name of the form
+// "ll.CHARSET" or "ll_CC.CHARSET" (two- or three-letter language code,
+// optional uppercase country code). It returns "" if locale does not have
+// that shape.
+func localeCharset(locale string) string {
+	n := 0
+	for n < len(locale) && locale[n] >= 'a' && locale[n] <= 'z' {
+		n++
+	}
+	if n < 2 || n > 3 {
+		return ""
+	}
+	rest := locale[n:]
+	if len(rest) >= 3 && rest[0] == '_' &&
+		rest[1] >= 'A' && rest[1] <= 'Z' && rest[2] >= 'A' && rest[2] <= 'Z' {
+		rest = rest[3:]
+	}
+	if len(rest) >= 2 && rest[0] == '.' {
+		return rest[1:]
+	}
+	return ""
 }
 
 func isEastAsian(locale string) bool {
 	charset := strings.ToLower(locale)
-	r := reLoc.FindStringSubmatch(locale)
-	if len(r) == 2 {
-		charset = strings.ToLower(r[1])
+	if cs := localeCharset(locale); cs != "" {
+		charset = strings.ToLower(cs)
 	}
 
 	if strings.HasSuffix(charset, "@cjk_narrow") {
@@ -46,10 +61,7 @@ func isEastAsian(locale string) bool {
 			break
 		}
 	}
-	max := 1
-	if m, ok := mblenTable[charset]; ok {
-		max = m
-	}
+	max := mblen(charset)
 	if max > 1 && (charset[0] != 'u' ||
 		strings.HasPrefix(locale, "ja") ||
 		strings.HasPrefix(locale, "ko") ||

--- a/runewidth_test.go
+++ b/runewidth_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"sync"
 	"testing"
 	"unicode/utf8"
 )
@@ -100,6 +101,41 @@ func TestRuneWidthChecksums(t *testing.T) {
 				testcase.name, gotSHA, testcase.wantSHA)
 		}
 	}
+}
+
+func TestStrictWidthLUT(t *testing.T) {
+	buildStrictWidthLUT()
+	lut := &strictWidthLUT
+	for r := rune(0); r <= utf8.MaxRune; r++ {
+		if got, want := int(lut[0][r]), runeWidthNoLUT(r, false, true); got != want {
+			t.Errorf("strictWidthLUT[0][%U] = %d, want %d", r, got, want)
+		}
+		if got, want := int(lut[1][r]), runeWidthNoLUT(r, true, true); got != want {
+			t.Errorf("strictWidthLUT[1][%U] = %d, want %d", r, got, want)
+		}
+	}
+}
+
+// TestRuneWidthConcurrent exercises concurrent first use of RuneWidth, so
+// that running it alone under -race checks readers against the lazy LUT
+// build. Run before other tests have built the LUT to be effective.
+func TestRuneWidthConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(ea bool) {
+			defer wg.Done()
+			c := NewCondition()
+			c.EastAsianWidth = ea
+			for r := rune(0); r <= utf8.MaxRune; r += 7 {
+				if w := c.RuneWidth(r); w < 0 || w > 2 {
+					t.Errorf("RuneWidth(%U) = %d", r, w)
+					return
+				}
+			}
+		}(i%2 == 0)
+	}
+	wg.Wait()
 }
 
 func TestDefaultLUT(t *testing.T) {


### PR DESCRIPTION
Fixes #104.

The `strictWidthLUT` introduced in v0.0.26 made `RuneWidth` considerably faster, but filling the 2 MB table during package init made every program that merely imports this package roughly 30 ms slower to start, and dirtied 2 MB of memory even when no width function was ever called.

This PR makes the build lazy without giving back any of the lookup speed. The range check at the top of `RuneWidth` now doubles as the lazy-initialization check: it compares the rune against an atomic limit that starts at 0x300 and becomes 0x110000 once the full table is built, so out-of-range runes and not-yet-built runes share the same cold path and the hot path has exactly the same number of branches as before — the only difference is that an immediate compare became a compare against a global, which is not measurable in the benchmarks. The first 0x300 entries of both planes are painted eagerly in init (a few microseconds), which also means programs that only ever measure ASCII/Latin-1 text never build the big table at all. Because the lazy build never rewrites those low entries, readers of that region cannot race the builder, and visibility of the high region is guaranteed by the acquire/release pair on the limit.

The build itself now paints whole intervals with a memcpy-speed fill instead of running two binary searches per code point, so the one-time cost when it does happen is about 1.3 ms instead of 30. The remaining init work got cheaper too: the merged interval tables are built lazily behind a `sync.Once`, and `runewidth_posix.go` no longer compiles a regexp or constructs a map at package load — the locale parsing is a small hand-written parser now, verified to behave identically to the old regexp on two million random inputs plus a list of real locale names, and dropping the `regexp` import also shrinks binaries a little.

Startup on the same machine (`GODEBUG=inittrace=1`, an empty program importing the package):

| version | init clock | init heap |
|---|---|---|
| v0.0.25 | 0.13 ms | 25728 B / 55 allocs |
| v0.0.27 | 23 ms | 25728 B / 55 allocs |
| this PR | 0.023–0.057 ms | 6952 B / 11 allocs |

Runtime performance is unchanged. Interleaved A/B runs against master with benchstat, focusing on the affected non-LUT path (n=12):

```
                        │     master     │            this PR             │
                        │     sec/op     │   sec/op     vs base           │
RuneWidthAll/regular-16     2.688m ± 2%     2.719m ± 3%  ~ (p=0.319 n=12)
RuneWidth768/regular-16     1.780µ ± 2%     1.778µ ± 2%  ~ (p=0.600 n=12)
```

<details>
<summary>Full benchmark suite (interleaved, n=4)</summary>

```
                                     │    master    │             this PR              │
                                     │    sec/op    │    sec/op     vs base            │
RuneWidthAll/regular-16                2.702m ± ∞ ¹    2.657m ± ∞ ¹       ~ (p=0.200)
RuneWidthAll/lut-16                    2.705m ± ∞ ¹    2.681m ± ∞ ¹       ~ (p=0.686)
RuneWidth768/regular-16                1.797µ ± ∞ ¹    1.735µ ± ∞ ¹  -3.42% (p=0.029)
RuneWidth768/lut-16                    1.755µ ± ∞ ¹    1.744µ ± ∞ ¹       ~ (p=0.686)
RuneWidthAllEastAsian/regular-16       2.651m ± ∞ ¹    2.665m ± ∞ ¹       ~ (p=1.000)
RuneWidthAllEastAsian/lut-16           2.839m ± ∞ ¹    2.737m ± ∞ ¹       ~ (p=0.200)
RuneWidth768EastAsian/regular-16       1.808µ ± ∞ ¹    1.752µ ± ∞ ¹       ~ (p=0.486)
RuneWidth768EastAsian/lut-16           1.783µ ± ∞ ¹    1.751µ ± ∞ ¹       ~ (p=0.457)
String1WidthAll/regular-16             11.39m ± ∞ ¹    11.12m ± ∞ ¹       ~ (p=0.114)
String1WidthAll/lut-16                 11.45m ± ∞ ¹    10.98m ± ∞ ¹       ~ (p=0.057)
String1Width768/regular-16             6.649µ ± ∞ ¹    6.302µ ± ∞ ¹  -5.23% (p=0.029)
String1Width768/lut-16                 6.776µ ± ∞ ¹    6.335µ ± ∞ ¹       ~ (p=0.057)
String1WidthAllEastAsian/regular-16    11.75m ± ∞ ¹    10.96m ± ∞ ¹       ~ (p=0.057)
String1WidthAllEastAsian/lut-16        11.23m ± ∞ ¹    11.18m ± ∞ ¹       ~ (p=0.686)
String1Width768EastAsian/regular-16    6.571µ ± ∞ ¹    6.322µ ± ∞ ¹  -3.78% (p=0.029)
String1Width768EastAsian/lut-16        6.639µ ± ∞ ¹    6.297µ ± ∞ ¹  -5.15% (p=0.029)
TablePrivate-16                        1.971m ± ∞ ¹    2.006m ± ∞ ¹       ~ (p=0.343)
TableNonprint-16                       746.3µ ± ∞ ¹    711.9µ ± ∞ ¹  -4.60% (p=0.029)
TableCombining-16                      6.054m ± ∞ ¹    5.756m ± ∞ ¹  -4.93% (p=0.029)
TableDoublewidth-16                    1.684m ± ∞ ¹    1.652m ± ∞ ¹       ~ (p=0.686)
TableAmbiguous-16                      5.722m ± ∞ ¹    5.681m ± ∞ ¹       ~ (p=0.486)
TableEmoji-16                          1.229m ± ∞ ¹    1.209m ± ∞ ¹       ~ (p=0.486)
TableNarrow-16                         592.1µ ± ∞ ¹    588.5µ ± ∞ ¹       ~ (p=0.886)
TableNeutral-16                        6.558m ± ∞ ¹    6.538m ± ∞ ¹       ~ (p=1.000)
FillLeftShort-16                       38.28n ± ∞ ¹    39.04n ± ∞ ¹       ~ (p=0.343)
FillLeftLong-16                        52.45n ± ∞ ¹    53.33n ± ∞ ¹       ~ (p=0.486)
FillRightShort-16                      37.50n ± ∞ ¹    40.21n ± ∞ ¹  +7.24% (p=0.029)
FillRightLong-16                       53.16n ± ∞ ¹    53.48n ± ∞ ¹       ~ (p=1.000)
geomean                                95.90µ          94.13µ        -1.84%
¹ need >= 6 samples for confidence interval at level 0.95
```

</details>

Correctness is covered by the existing checksum tests plus two new ones: `TestStrictWidthLUT` verifies the painted table matches `runeWidthNoLUT` for every code point in both planes, and `TestRuneWidthConcurrent` exercises the cold-start build from eight goroutines so that running it alone under `-race` checks the reader/builder interaction. The full suite passes with `-race`, and js/wasm, windows and darwin builds were verified.


---

For the bigger picture, here is the same code compared against v0.0.25 — the last release before the LUT existed — using an external benchmark module that exercises only the public API, with `go.mod` pointed at each version in interleaved runs (n=12). Nothing is slower than v0.0.25 and the geomean is about 46% faster: the LUT speedup from v0.0.26 is fully preserved (`RuneWidth` over CJK and full-range sweeps is 77–84% faster than the binary searches), ASCII `StringWidth` is identical because both versions short-circuit it, and the CJK/emoji `StringWidth` numbers are faster even though this code now also performs grapheme cluster segmentation (which changes the reported *width* of ZWJ emoji sequences — one glyph, two cells — so those values intentionally differ from v0.0.25). Allocation counts are identical everywhere.

```
                     │   v0.0.25    │      this PR        vs base
RuneWidthASCII-16      222.8n ± 3%   201.9n ± 2%    -9.36% (p=0.000)
RuneWidthCJK-16       2566.5n ± 1%   398.3n ± 1%   -84.48% (p=0.000)
RuneWidthAll-16        597.2µ ± 1%   135.9µ ± 1%   -77.24% (p=0.000)
StringWidthASCII-16    98.38n ± 3%   98.05n ± 2%         ~ (p=0.876)
StringWidthCJK-16      3.076µ ± 1%   1.767µ ± 2%   -42.56% (p=0.000)
StringWidthMixed-16    2.467µ ± 2%   2.004µ ± 3%   -18.79% (p=0.000)
StringWidthEmoji-16    2.736µ ± 1%   1.558µ ± 8%   -43.06% (p=0.000)
TruncateCJK-16         3.892µ ± 8%   2.200µ ± 3%   -43.47% (p=0.000)
WrapMixed-16           1.473µ ± 6%   1.048µ ± 8%   -28.83% (p=0.000)
FillRightCJK-16        266.9n ± 2%   171.1n ± 1%   -35.88% (p=0.000)
geomean                2.008µ        1.088µ        -45.80%
```
